### PR TITLE
Update GitHub Actions runner to ubuntu-22.04

### DIFF
--- a/.github/workflows/pack.yaml
+++ b/.github/workflows/pack.yaml
@@ -17,7 +17,7 @@ jobs:
       github.event_name != 'release' ||
       (github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v'))
     name: Generate pack
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This PR updates the GitHub Actions runner from ubuntu-20.04 to ubuntu-22.04.